### PR TITLE
Basic functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,100 @@
+# Generic
+mysql_env: &mysql_env
+  TZ: "/usr/share/zoneinfo/America/Chicago"
+
+wait_for_mysql: &wait_for_mysql
+  run:
+    name: Wait for db
+    command: dockerize -wait tcp://localhost:3306 -timeout 1m
+
+checkout: &checkout
+  checkout:
+    path: ~/system_variable
+
+ruby_defaults: &ruby_defaults
+  working_directory: ~/system_variable
+
+ruby_restore_cache: &ruby_restore_cache
+  restore_cache:
+    keys:
+      - system_variable-{{ checksum "Gemfile" }}
+      - system_variable-
+
+ruby_save_cache: &ruby_save_cache
+  save_cache:
+    key: system_variable-{{ checksum "Gemfile" }}
+    paths:
+      - vendor/bundle
+
+ruby_bundle: &ruby_bundle
+  run:
+    name: 'Install Dependencies'
+    command: |
+      gem install bundler
+      echo $GITHUB_OAUTH_CREDENTIALS
+      bundle config https://rubygems.pkg.github.com/bodyshopbidsdotcom $GITHUB_OAUTH_CREDENTIALS
+      bundle check || bundle install --jobs=4 --retry=3
+
+ruby_db_setup: &ruby_db_setup
+  run:
+    name: Database Setup
+    command: |
+      bundle exec rake db:create db:schema:load --trace RAILS_ENV=test
+      bundle exec rake db:test:prepare
+
+ruby_docker_env: &ruby_docker_env
+  RAILS_ENV: test
+  RACK_ENV: test
+
+image_defaults: &image_defaults
+  <<: *ruby_defaults
+  docker:
+    - image: circleci/ruby:2.5
+      environment: *ruby_docker_env
+    - image: circleci/mysql:5.7
+      environment: *mysql_env
+
+version: 2
+jobs:
+  build-and-test-rails:
+    <<: *ruby_defaults
+    <<: *image_defaults
+    steps:
+      - <<: *checkout
+      - <<: *ruby_restore_cache
+      - <<: *ruby_bundle
+      - <<: *ruby_save_cache
+      - <<: *wait_for_mysql
+      - <<: *ruby_db_setup
+      - run: bundle exec rspec
+  lint:
+    <<: *ruby_defaults
+    <<: *image_defaults
+    steps:
+      - <<: *checkout
+      - <<: *ruby_restore_cache
+      - <<: *ruby_bundle
+      - <<: *ruby_save_cache
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
+  brakeman:
+    <<: *ruby_defaults
+    <<: *image_defaults
+    steps:
+      - <<: *checkout
+      - <<: *ruby_restore_cache
+      - <<: *ruby_bundle
+      - <<: *ruby_save_cache
+      - run:
+          name: Brakeman Security Scan
+          command: bundle exec brakeman
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-and-test-rails
+      - lint
+      - brakeman

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ spec/dummy/db/*.sqlite3-*
 spec/dummy/log/*.log
 spec/dummy/storage/
 spec/dummy/tmp/
+
+# Ignore application configuration
+/config/application.yml
+/spec/dummy/config/application.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+inherit_gem:
+  snap-style:
+    - "rubocop/rubocop.yml"
+
+AllCops:
+  Exclude:
+    - 'db/migrate/*'
+    - 'spec/dummy/db/schema.rb'
+    - 'config/**/*'
+    - 'bin/*'
+    - 'vendor/**/*'
+    - 'spec/dummy/config/*'
+
+Rails:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: 'ruby19'
+
+# Don't require space around parameter defaults, def foo(msg="bar") vs def foo(msg = "bar")
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Exclude:
+    - 'spec/**/*'
+
+# Only enforce block length outside of specs
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Lint/AmbiguousBlockAssociation:
+    Exclude:
+    - 'spec/**/*'
+
+Metrics/PerceivedComplexity:
+    Max: 15

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,9 @@ gemspec
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
+
+group :development, :test do
+  source 'https://rubygems.pkg.github.com/bodyshopbidsdotcom' do
+    gem 'snap-style', '2.0.0'
+  end
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
 
 GEM
   remote: https://rubygems.org/
+  remote: https://rubygems.pkg.github.com/bodyshopbidsdotcom/
   specs:
     actioncable (5.2.4.3)
       actionpack (= 5.2.4.3)
@@ -51,13 +52,14 @@ GEM
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 13.0)
     arel (9.0.0)
-    brakeman (4.8.2)
+    ast (2.4.1)
+    brakeman (4.9.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crass (1.0.6)
-    database_cleaner (1.7.0)
+    database_cleaner (1.8.5)
     diff-lcs (1.4.4)
     erubi (1.9.0)
     factory_bot (5.2.0)
@@ -90,6 +92,10 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
+    powerpack (0.1.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -123,6 +129,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -145,8 +152,18 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.10.1)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
+    snap-style (2.0.0)
+      rubocop (~> 0.52.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -158,6 +175,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -180,7 +198,9 @@ DEPENDENCIES
   rake (~> 10.0)
   rspec (~> 3.0)
   rspec-rails (~> 3.9)
+  rubocop (~> 0.52)
   shoulda-matchers (~> 4.1)
+  snap-style (= 2.0.0)!
   system_variable!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
       railties (>= 4.2.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
     generator_spec (0.9.4)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -190,6 +192,7 @@ DEPENDENCIES
   database_cleaner
   factory_bot_rails (~> 5.1)
   faker (~> 2.10)
+  figaro (~> 1.2)
   generator_spec (~> 0.9)
   mysql2 (~> 0.5)
   pry (~> 0.12)

--- a/README.md
+++ b/README.md
@@ -14,21 +14,82 @@ gem 'system_variable'
 
 And then execute:
 
-    $ bundle
+    $ bundle i
 
 Or install it yourself as:
 
     $ gem install system_variable
 
+Once installed, install any SystemVariable migrations
+
+    $ rake system_variable:install:migrations
+
+## Configuration
+
+SystemVariable can be configured using an initializer file in your rails application.
+
+```ruby
+# config/initializers/system_variable.rb
+
+SystemVariable.configure do |config|
+  config.external_sources = [ENV] # An array of variable sources, such as ENV or AWS Secrets.
+                                  # Each element should be a Hash or conform to a Hash interface.
+                                  # When fetching values, external sources are checked in the order they're defined here.
+                                  # Default: [ENV]
+  @cache_key = 'system_variable'  # Allows the key used by Rails cache to be configurable
+                                  # Default: 'system_variable'
+  @caching_enabled = true         # Enables caching of native SystemVariable variables.
+                                  # Default: true
+end
+```
+
 ## Usage
 
-TODO: Write usage instructions here
+Fetching variables
+```ruby
+SystemVariable.fetch('EXTERNAL_APPLICATION_URL') # 'https://externalurl.test
+```
+
+Return default values if variable isn't found, or the found value is `nil`.
+```ruby
+SystemVariable.fetch('EXTERNAL_APPLICATION_URL', default: 'http://defaulturl.test') # 'http://defaulturl.test'
+```
+
+Check if a variable key is defined
+```ruby
+SystemVariable.exists?('EXTERNAL_APPLICATION_URL')
+```
+
+NOTE: All lookup methods (fetch/exists?) will look at native SystemVariable values _first_, then check any defined external sources.
+
+Create a new variable
+```ruby
+SystemVariable::Variable.create(key: 'MY_NEW_VARIABLE', value: 'foo')
+```
+
+Create a new variable and assign it to a category
+```ruby
+SystemVariable::Variable.create(key: 'MY_NEW_VARIABLE', value: 'foo', category_attributes: { name: 'My Category' })
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Install Dependencies
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+    $ bundle i
+
+Setup the database
+
+    $ bundle exec rake db:create
+    $ bundle exec rake db:schema:load
+
+Run migrations
+
+    $ bundle exec rake db:migrate
+
+Run tests
+
+    $ bundle exec rspec
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ SystemVariable.configure do |config|
                                   # Default: 'system_variable'
   @caching_enabled = true         # Enables caching of native SystemVariable variables.
                                   # Default: true
+  @cache_expiration = 24.hours    # Sets expiration time on cached values
+                                  # Default: 24.hours
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,23 @@ SystemVariable can be configured using an initializer file in your rails applica
 # config/initializers/system_variable.rb
 
 SystemVariable.configure do |config|
-  config.external_sources = [ENV] # An array of variable sources, such as ENV or AWS Secrets.
-                                  # Each element should be a Hash or conform to a Hash interface.
-                                  # When fetching values, external sources are checked in the order they're defined here.
-                                  # Default: [ENV]
-  @cache_key = 'system_variable'  # Allows the key used by Rails cache to be configurable
-                                  # Default: 'system_variable'
-  @caching_enabled = true         # Enables caching of native SystemVariable variables.
-                                  # Default: true
-  @cache_expiration = 24.hours    # Sets expiration time on cached values
-                                  # Default: 24.hours
+  # An array of variable sources, such as ENV or AWS Secrets.
+  # Each element should be a Hash or conform to a Hash interface.
+  # When fetching values, external sources are checked in the order they're defined here.
+  # Default: [SystemVariable::Variable, ENV]
+  config.sources = [SystemVariable::Variable, ENV] 
+  
+  # Allows the key used by Rails cache to be configurable
+  # Default: 'system_variable'
+  @cache_key = 'system_variable'  
+ 
+  # Enables caching of native SystemVariable variables.
+  # Default: true
+  @caching_enabled = true 
+  
+  # Sets expiration time on cached values
+  # Default: 24.hours        
+  @cache_expiration = 24.hours    
 end
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
+APP_RAKEFILE = File.expand_path('spec/dummy/Rakefile', __dir__)
 load 'rails/tasks/engine.rake'
 
 load 'rails/tasks/statistics.rake'

--- a/app/models/system_variable/category.rb
+++ b/app/models/system_variable/category.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: system_variable_categories
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_system_variable_categories_on_name  (name) UNIQUE
+#
+
+module SystemVariable
+  class Category < ApplicationRecord
+    has_many :variables
+
+    validates_presence_of :name
+  end
+end

--- a/app/models/system_variable/variable.rb
+++ b/app/models/system_variable/variable.rb
@@ -35,7 +35,7 @@ module SystemVariable
     class << self
       def all_values
         if SystemVariable.config.caching_enabled
-          Rails.cache.fetch(SystemVariable.config.cache_key, expires_in: 24.hour) { self.hashify }
+          Rails.cache.fetch(SystemVariable.config.cache_key, expires_in: SystemVariable.config.cache_expiration) { self.hashify }
         else
           self.hashify
         end

--- a/app/models/system_variable/variable.rb
+++ b/app/models/system_variable/variable.rb
@@ -35,14 +35,14 @@ module SystemVariable
     class << self
       def all_values
         if SystemVariable.config.caching_enabled
-          Rails.cache.fetch(SystemVariable.config.cache_key, :expires_in => 24.hour) { self.hashify }
+          Rails.cache.fetch(SystemVariable.config.cache_key, expires_in: 24.hour) { self.hashify }
         else
           self.hashify
         end
       end
 
       def hashify
-        self.all.map{ |variable| [variable.key, variable.value] }.to_h
+        self.all.map { |variable| [variable.key, variable.value] }.to_h
       end
 
       def get(key)

--- a/app/models/system_variable/variable.rb
+++ b/app/models/system_variable/variable.rb
@@ -45,12 +45,12 @@ module SystemVariable
         self.all.map { |variable| [variable.key, variable.value] }.to_h
       end
 
-      def get(key)
+      def fetch(key, default=nil)
         key = self.sanitize_key(key)
-        self.all_values.dig(key)
+        self.all_values.dig(key) || default
       end
 
-      def exists?(key)
+      def key?(key)
         key = self.sanitize_key(key)
         self.all_values.key?(key)
       end

--- a/app/models/system_variable/variable.rb
+++ b/app/models/system_variable/variable.rb
@@ -33,8 +33,12 @@ module SystemVariable
     end
 
     class << self
-      def cached_values
-        Rails.cache.fetch('system_variables', :expires_in => 24.hour) { self.hashify }
+      def all_values
+        if SystemVariable.config.caching_enabled
+          Rails.cache.fetch(SystemVariable.config.cache_key, :expires_in => 24.hour) { self.hashify }
+        else
+          self.hashify
+        end
       end
 
       def hashify
@@ -43,12 +47,12 @@ module SystemVariable
 
       def get(key)
         key = self.sanitize_key(key)
-        self.cached_values.dig(key)
+        self.all_values.dig(key)
       end
 
       def exists?(key)
         key = self.sanitize_key(key)
-        self.cached_values.key?(key)
+        self.all_values.key?(key)
       end
 
       def sanitize_key(key)
@@ -61,7 +65,7 @@ module SystemVariable
     end
 
     def clear_cache
-      Rails.cache.delete('system_variables')
+      Rails.cache.delete(SystemVariable.config.cache_key) if SystemVariable.config.caching_enabled
     end
   end
 end

--- a/app/models/system_variable/variable.rb
+++ b/app/models/system_variable/variable.rb
@@ -1,0 +1,67 @@
+# == Schema Information
+#
+# Table name: system_variable_variables
+#
+#  id          :bigint(8)        not null, primary key
+#  description :string(255)
+#  key         :string(255)      not null
+#  value       :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint(8)
+#
+# Indexes
+#
+#  index_system_variable_variables_on_category_id  (category_id)
+#  index_system_variable_variables_on_key          (key) UNIQUE
+#
+
+module SystemVariable
+  class Variable < ApplicationRecord
+    belongs_to :category, optional: true
+
+    validates_presence_of :key
+
+    accepts_nested_attributes_for :category
+
+    before_save :sanitize
+    after_commit :clear_cache
+
+    def sanitize
+      self.key = self.class.sanitize_key(self.key)
+      self.value = self.class.sanitize_value(self.value) || ''
+    end
+
+    class << self
+      def cached_values
+        Rails.cache.fetch('system_variables', :expires_in => 24.hour) { self.hashify }
+      end
+
+      def hashify
+        self.all.map{ |variable| [variable.key, variable.value] }.to_h
+      end
+
+      def get(key)
+        key = self.sanitize_key(key)
+        self.cached_values.dig(key)
+      end
+
+      def exists?(key)
+        key = self.sanitize_key(key)
+        self.cached_values.key?(key)
+      end
+
+      def sanitize_key(key)
+        key.try(:upcase).try(:strip)
+      end
+
+      def sanitize_value(key)
+        key.try(:strip)
+      end
+    end
+
+    def clear_cache
+      Rails.cache.delete('system_variables')
+    end
+  end
+end

--- a/db/migrate/20200731183026_create_system_variable_categories.rb
+++ b/db/migrate/20200731183026_create_system_variable_categories.rb
@@ -1,0 +1,10 @@
+class CreateSystemVariableCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :system_variable_categories do |t|
+      t.string :name, null: false
+      t.timestamps
+
+      t.index :name, unique: true
+    end
+  end
+end

--- a/db/migrate/20200731183033_create_system_variable_variables.rb
+++ b/db/migrate/20200731183033_create_system_variable_variables.rb
@@ -1,0 +1,14 @@
+class CreateSystemVariableVariables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :system_variable_variables do |t|
+      t.string :key, null: false
+      t.string :value
+      t.string :description
+      t.timestamps
+
+      t.references :category, foreignkey: true
+
+      t.index [:key], unique: true
+    end
+  end
+end

--- a/lib/system_variable.rb
+++ b/lib/system_variable.rb
@@ -12,12 +12,11 @@ module SystemVariable
     end
 
     def fetch(key, default: nil)
-      value = SystemVariable::Variable.get(key)
-      if value.nil?
-        config.external_sources.each do |source|
-          value = source.fetch(key, nil)
-          break unless value.nil?
-        end
+      value = nil
+
+      config.sources.each do |source|
+        value = source.fetch(key, nil)
+        break unless value.nil?
       end
 
       if value.nil?
@@ -28,7 +27,7 @@ module SystemVariable
     end
 
     def exists?(key)
-      SystemVariable::Variable.exists?(key) || config.external_sources.any? { |source| source.key? key }
+      config.sources.any? { |source| source.key? key }
     end
   end
 end

--- a/lib/system_variable.rb
+++ b/lib/system_variable.rb
@@ -1,5 +1,36 @@
-require "system_variable/engine"
+require 'system_variable/engine'
+require 'system_variable/config'
+require 'pry'
 
 module SystemVariable
-  # Your code goes here...
+
+  class << self
+    def configure
+      yield(self.config) if block_given?
+    end
+
+    def config
+      @_config ||= Config.new
+    end
+
+    def fetch(key, default: nil)
+      value = SystemVariable::Variable.get(key)
+      if value.nil?
+        config.external_sources.each do |source|
+          value = source.fetch(key, nil)
+          break unless value.nil?
+        end
+      end
+
+      if value.nil?
+        default
+      else
+        value
+      end
+    end
+
+    def exists?(key)
+      SystemVariable::Variable.exists?(key) || config.external_sources.any? { |source| source.key? key }
+    end
+  end
 end

--- a/lib/system_variable.rb
+++ b/lib/system_variable.rb
@@ -3,7 +3,6 @@ require 'system_variable/config'
 require 'pry'
 
 module SystemVariable
-
   class << self
     def configure
       yield(self.config) if block_given?

--- a/lib/system_variable.rb
+++ b/lib/system_variable.rb
@@ -1,6 +1,5 @@
 require 'system_variable/engine'
 require 'system_variable/config'
-require 'pry'
 
 module SystemVariable
   class << self

--- a/lib/system_variable/config.rb
+++ b/lib/system_variable/config.rb
@@ -1,0 +1,13 @@
+module SystemVariable
+  class Config
+    attr_accessor :external_sources,
+                  :cache_key,
+                  :caching_enabled
+
+    def initialize
+      @external_sources = [ENV]
+      @cache_key = 'system_variable'
+      @caching_enabled = true
+    end
+  end
+end

--- a/lib/system_variable/config.rb
+++ b/lib/system_variable/config.rb
@@ -2,12 +2,14 @@ module SystemVariable
   class Config
     attr_accessor :external_sources,
                   :cache_key,
-                  :caching_enabled
+                  :caching_enabled,
+                  :cache_expiration
 
     def initialize
       @external_sources = [ENV]
       @cache_key = 'system_variable'
       @caching_enabled = true
+      @cache_expiration = 24.hours
     end
   end
 end

--- a/lib/system_variable/config.rb
+++ b/lib/system_variable/config.rb
@@ -1,12 +1,12 @@
 module SystemVariable
   class Config
-    attr_accessor :external_sources,
-                  :cache_key,
+    attr_accessor :cache_key,
                   :caching_enabled,
-                  :cache_expiration
+                  :cache_expiration,
+                  :sources
 
     def initialize
-      @external_sources = [ENV]
+      @sources = [SystemVariable::Variable, ENV]
       @cache_key = 'system_variable'
       @caching_enabled = true
       @cache_expiration = 24.hours

--- a/lib/system_variable/version.rb
+++ b/lib/system_variable/version.rb
@@ -1,3 +1,3 @@
 module SystemVariable
-  VERSION = '0.1.0'
+  VERSION = '0.1.0'.freeze
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -80,7 +80,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,0 +1,33 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_07_31_183033) do
+
+  create_table "system_variable_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_system_variable_categories_on_name", unique: true
+  end
+
+  create_table "system_variable_variables", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "value"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_system_variable_variables_on_category_id"
+    t.index ["key"], name: "index_system_variable_variables_on_key", unique: true
+  end
+
+end

--- a/spec/factories/system_variable/category.rb
+++ b/spec/factories/system_variable/category.rb
@@ -1,0 +1,7 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :system_variables_category, class: 'SystemVariable::Category' do
+    name { Faker::String.random(length: 16) }
+  end
+end

--- a/spec/factories/system_variable/variables.rb
+++ b/spec/factories/system_variable/variables.rb
@@ -1,0 +1,9 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :system_variable_variable, class: 'SystemVariable::Variable' do
+    key { Faker::String.random(length: 16) }
+    value { Faker::String.random(length: 16) }
+    category { FactoryBot.build(:system_variables_category) }
+  end
+end

--- a/spec/models/system_variable/category_spec.rb
+++ b/spec/models/system_variable/category_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe SystemVariable::Category do
+  describe 'associations' do
+    it { is_expected.to have_many(:variables) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/system_variable/variable_spec.rb
+++ b/spec/models/system_variable/variable_spec.rb
@@ -9,23 +9,22 @@ describe SystemVariable::Variable do
     it { is_expected.to validate_presence_of(:key) }
   end
 
-
   describe '#hashify' do
     let(:owner) { SystemVariable::DefaultOwner.create }
 
     it 'formats variables into a hash' do
-      variable_1 = create(:system_variable_variable, key: 'var1')
-      variable_2 = create(:system_variable_variable, key: 'var2')
-      variable_3 = create(:system_variable_variable, key: 'var3')
-      variable_4 = create(:system_variable_variable, key: 'var4')
+      variable1 = create(:system_variable_variable, key: 'var1')
+      variable2 = create(:system_variable_variable, key: 'var2')
+      variable3 = create(:system_variable_variable, key: 'var3')
+      variable4 = create(:system_variable_variable, key: 'var4')
 
       result = described_class.hashify
 
       expect(result.with_indifferent_access).to eq({
-        VAR1: variable_1.value,
-        VAR2: variable_2.value,
-        VAR3: variable_3.value,
-        VAR4: variable_4.value
+        VAR1: variable1.value,
+        VAR2: variable2.value,
+        VAR3: variable3.value,
+        VAR4: variable4.value
       }.with_indifferent_access)
     end
   end

--- a/spec/models/system_variable/variable_spec.rb
+++ b/spec/models/system_variable/variable_spec.rb
@@ -29,27 +29,31 @@ describe SystemVariable::Variable do
     end
   end
 
-  describe '#get' do
+  describe '#fetch' do
     it 'retrieves values' do
       create(:system_variable_variable, key: 'var1', value: 'var1 value')
 
-      expect(described_class.get('var1')).to eq('var1 value')
+      expect(described_class.fetch('var1')).to eq('var1 value')
     end
 
     it 'returns nil if key does not exist and no default is specified' do
-      expect(described_class.get('fake_key')).to be_nil
+      expect(described_class.fetch('fake_key')).to be_nil
+    end
+
+    it 'returns nil if key does not exist and default is specified' do
+      expect(described_class.fetch('fake_key', 'foo')).to eq('foo')
     end
   end
 
-  describe '#exists?' do
+  describe '#key?' do
     it 'returns true if key exists' do
       create(:system_variable_variable, key: 'var1', value: 'var1 value')
 
-      expect(described_class.exists?('var1')).to eq(true)
+      expect(described_class.key?('var1')).to eq(true)
     end
 
     it 'returns false if key does not exists' do
-      expect(described_class.exists?('fake_key')).to eq(false)
+      expect(described_class.key?('fake_key')).to eq(false)
     end
   end
 

--- a/spec/models/system_variable/variable_spec.rb
+++ b/spec/models/system_variable/variable_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe SystemVariable::Variable do
+  describe 'associations' do
+    it { is_expected.to belong_to(:category).optional }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:key) }
+  end
+
+
+  describe '#hashify' do
+    let(:owner) { SystemVariable::DefaultOwner.create }
+
+    it 'formats variables into a hash' do
+      variable_1 = create(:system_variable_variable, key: 'var1')
+      variable_2 = create(:system_variable_variable, key: 'var2')
+      variable_3 = create(:system_variable_variable, key: 'var3')
+      variable_4 = create(:system_variable_variable, key: 'var4')
+
+      result = described_class.hashify
+
+      expect(result.with_indifferent_access).to eq({
+        VAR1: variable_1.value,
+        VAR2: variable_2.value,
+        VAR3: variable_3.value,
+        VAR4: variable_4.value
+      }.with_indifferent_access)
+    end
+  end
+
+  describe '#get' do
+    it 'retrieves values' do
+      create(:system_variable_variable, key: 'var1', value: 'var1 value')
+
+      expect(described_class.get('var1')).to eq('var1 value')
+    end
+
+    it 'returns nil if key does not exist and no default is specified' do
+      expect(described_class.get('fake_key')).to be_nil
+    end
+  end
+
+  describe '#exists?' do
+    it 'returns true if key exists' do
+      create(:system_variable_variable, key: 'var1', value: 'var1 value')
+
+      expect(described_class.exists?('var1')).to eq(true)
+    end
+
+    it 'returns false if key does not exists' do
+      expect(described_class.exists?('fake_key')).to eq(false)
+    end
+  end
+
+  describe '#sanitize_key' do
+    it 'sanitizes' do
+      expect(described_class.sanitize_key(' foo ')).to eq('FOO')
+    end
+  end
+
+  describe '#sanitize_value' do
+    it 'sanitizes' do
+      expect(described_class.sanitize_value(' foo ')).to eq('foo')
+    end
+  end
+end

--- a/spec/system_variable_spec.rb
+++ b/spec/system_variable_spec.rb
@@ -9,7 +9,7 @@ describe SystemVariable do
     end
 
     it 'returns value from ENV if not defined in SystemVariable' do
-      expect(ENV).to receive(:fetch).with("BAR", nil).and_return("ENV value")
+      expect(ENV).to receive(:fetch).with('BAR', nil).and_return('ENV value')
 
       expect(described_class.fetch('BAR')).to eq('ENV value')
     end
@@ -31,7 +31,7 @@ describe SystemVariable do
     end
 
     it 'returns true if found in ENV' do
-      expect(ENV).to receive(:key?).with("BAR").and_return(true)
+      expect(ENV).to receive(:key?).with('BAR').and_return(true)
 
       expect(described_class.exists?('BAR')).to eq(true)
     end

--- a/spec/system_variable_spec.rb
+++ b/spec/system_variable_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe SystemVariable do
+  describe '#fetch' do
+    it 'returns value defined in SystemVariable' do
+      create(:system_variable_variable, key: 'foo', value: 'native value')
+
+      expect(described_class.fetch('foo')).to eq('native value')
+    end
+
+    it 'returns value from ENV if not defined in SystemVariable' do
+      expect(ENV).to receive(:fetch).with("BAR", nil).and_return("ENV value")
+
+      expect(described_class.fetch('BAR')).to eq('ENV value')
+    end
+
+    it 'returns nil if not found in any sources' do
+      expect(described_class.fetch('NON_EXISTANT')).to be_nil
+    end
+
+    it 'returns default value if not found in any sources' do
+      expect(described_class.fetch('NON_EXISTANT', default: 'foo')).to eq('foo')
+    end
+  end
+
+  describe '#exists?' do
+    it 'returns true if found in SystemVariable' do
+      create(:system_variable_variable, key: 'foo')
+
+      expect(described_class.exists?('foo')).to eq(true)
+    end
+
+    it 'returns true if found in ENV' do
+      expect(ENV).to receive(:key?).with("BAR").and_return(true)
+
+      expect(described_class.exists?('BAR')).to eq(true)
+    end
+
+    it 'returns false if not found in any sources' do
+      expect(described_class.exists?('NON_EXISTANT')).to eq(false)
+    end
+  end
+end

--- a/system_variable.gemspec
+++ b/system_variable.gemspec
@@ -1,18 +1,18 @@
-$:.push File.expand_path("lib", __dir__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
-require "system_variable/version"
+require 'system_variable/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name          = "system_variable"
+  spec.name          = 'system_variable'
   spec.version       = SystemVariable::VERSION
-  spec.authors       = ["Santiago Herrera"]
-  spec.email         = ["santiago@snapsheet.me"]
+  spec.authors       = ['Santiago Herrera']
+  spec.email         = ['santiago@snapsheet.me']
 
-  spec.summary       = %q{Database-driven environment variables}
-  spec.homepage      = "https://github.com/bodyshopbidsdotcom/system_variable"
-  spec.license       = "MIT"
+  spec.summary       = 'Database-driven environment variables'
+  spec.homepage      = 'https://github.com/bodyshopbidsdotcom/system_variable'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     'public gem pushes.'
   end
 
-  spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_development_dependency 'annotate', '~> 2.7'
   spec.add_development_dependency 'brakeman', '~> 4.7'
@@ -34,11 +34,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faker', '~> 2.10'
   spec.add_development_dependency 'generator_spec', '~> 0.9'
   spec.add_development_dependency 'mysql2', '~> 0.5'
-  spec.add_development_dependency 'pry-byebug', '~> 3.7'
   spec.add_development_dependency 'pry', '~> 0.12'
+  spec.add_development_dependency 'pry-byebug', '~> 3.7'
   spec.add_development_dependency 'rails', '~> 5.2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec-rails', '~> 3.9'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-rails', '~> 3.9'
+  spec.add_development_dependency 'rubocop', '~> 0.52'
   spec.add_development_dependency 'shoulda-matchers', '~> 4.1'
 end

--- a/system_variable.gemspec
+++ b/system_variable.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'factory_bot_rails', '~> 5.1'
   spec.add_development_dependency 'faker', '~> 2.10'
+  spec.add_development_dependency 'figaro', '~> 1.2'
   spec.add_development_dependency 'generator_spec', '~> 0.9'
   spec.add_development_dependency 'mysql2', '~> 0.5'
   spec.add_development_dependency 'pry', '~> 0.12'


### PR DESCRIPTION
## What

Turning CORE's System Variable logic into a gem

Note: This is not a 1-to-1 port, there's a few liberties I took which I think makes more sense in a more general application.

Depends on https://github.com/bodyshopbidsdotcom/system_variable/pull/1

## Why

It's a nifty feature as it allows applications to update many of their system variables without needing to re-deploy

## How

Major differences between and the original implementation
1. Order of Native DB/ENV and other sources is configurable
2. This doesn't include any casting methods. I'm thinking on future iterations it would be useful to instead store a 'data_type' value along with these values so that this casting can happen automatically.
3. ENV is available by default, but variable sources are now configurable in order to accommodate both ENV and Secrets

## Testing

1. clone this repo and open a rails console.
2. Verify that `fetch` and `exists?` methods work as expected

Add ENV variables:
figaro is added, so you can add ENV variables in `spec/dummy/config/application.yml`

Add variables to SystemVariable DB
```ruby
SystemVariable::Variable.create(key: 'FOO', value: 'bar')
```

Change SystemVariable configurations:
There's a stubbed initializer with defaults set in `spec/dummy/config/initializers/system_variable.rb`

Test things
```
SystemVariable.fetch('FOO', default: 'bar')
SysetmVariable.exists?('FOO')
```

<!-- SNAPHUB_TIPS_STARTS -->
---
## SnapHub Tips
You can rollback the migrations on this branch with
```
rake db:migrate:down VERSION=20200731183033 && \
rake db:migrate:down VERSION=20200731183026
```
<!-- SNAPHUB_TIPS_ENDS -->