### PR TITLE
Add codeowners and label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+* @bodyshopbidsdotcom/backend_committee

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+BACKEND_COMMITTEE:
+  - '**/*'
+  - '.**/*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,10 @@
+name: AutoLabeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Adds CODEOWNERS and an automatic label for BACKEND_COMMITTEE so we can find pull requests more easily

https://github.com/orgs/bodyshopbidsdotcom/teams/backend-committee